### PR TITLE
Vectorise softmax exp with builtin DSD ops (identical output)

### DIFF
--- a/Decode/src/decode.csl
+++ b/Decode/src/decode.csl
@@ -268,6 +268,9 @@ var local_sum_dsd = @get_dsd(mem1d_dsd, .{ .base_address = &local_sum, .extent =
 var sum: f16 = 0.0;
 var ptr_sum = &sum;
 
+var ones_score: [bsz * seq_len_p_pe]f16 = @constants([bsz * seq_len_p_pe]f16, 1.0);
+var ones_score_dsd = @get_dsd(mem1d_dsd, .{ .base_address = &ones_score, .extent = bsz * seq_len_p_pe });
+
 var local_max: [bsz]f16 = @zeros([bsz]f16);
 var ptr_local_max: [*]f16 = &local_max;
 var local_max_dsd = @get_dsd(mem1d_dsd, .{ .base_address = &local_max, .extent = bsz });
@@ -546,8 +549,17 @@ fn softmax_score() void {
     @load_to_dsr(dest_dsr_1, seq_len_p_pe_dsd_1, .{ .save_address = true });
     @load_to_dsr(src0_dsr_1, seq_len_p_pe_dsd_2, .{ .save_address = true });
     @map(fsubh_func, local_max_dsd);
+    
+    // vectorised e^x = (1 + x * 1/256)^4
+    @load_to_dsr(dest_dsr_1, score_dsd);
+    @load_to_dsr(src0_dsr_1, ones_score_dsd);
+    @load_to_dsr(src1_dsr_1, score_tmp_dsd);
+    @fmach(dest_dsr_1, src0_dsr_1, src1_dsr_1, @as(f16, 1.0 / 256.0));
 
-    @map(fast_exp, score_tmp_dsd, score_dsd);
+    @load_to_dsr(src0_dsr_1, score_dsd);
+    @load_to_dsr(src1_dsr_1, score_dsd);
+    @fmulh(dest_dsr_1, src0_dsr_1, src1_dsr_1); 
+    @fmulh(dest_dsr_1, src0_dsr_1, src1_dsr_1); 
 
     seq_len_p_pe_dsd_1 = @set_dsd_base_addr(seq_len_p_pe_dsd_1, ptr_score);
     @load_to_dsr(src1_dsr_1, seq_len_p_pe_dsd_1, .{ .save_address = true });


### PR DESCRIPTION
### Description

Rewrites the `exp` step in `softmax_score` (decode) from a per-element
`@map(fast_exp, ...)` into whole-vector DSD ops (`@fmach` + two `@fmulh`)
over the score buffer.


### Correctness

Output is bit-identical to the current fast_exp: same (1 + x/256)⁴ formula, evaluated as vector ops instead of per-element scalar calls. The squaring count is unchanged, so this is a pure performance change with no effect on model output. (If a more accurate exp is ever wanted, the same structure extends to (1 + x/256)²⁵⁶ by looping the `@fmulh` eight times but I've kept it identical here so this PR doesn't change numerics.)

### Performance gain

Profiling the attention operation in isolation, the softmax exp becomes a bottleneck as PEs become saturated because it is a serialised operation. Using builtins enables SIMD. 

Cycle breakdown at P = 64:

Existing serial @map:
<img width="830" height="560" alt="serial map exp" src="https://github.com/user-attachments/assets/759cf176-c550-4479-b6f3-c91a703b5e1c" />
Proposed vectorised version:
<img width="830" height="560" alt="vectorised exp" src="https://github.com/user-attachments/assets/7db60f81-93fa-45ce-920c-457d2168f726" />